### PR TITLE
1、grunt加载task由手工转为自动化操作。  2、增加在线tinypng压缩图片功能（默认关闭）

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,6 +23,8 @@
     "grunt-hashres": "~0.4.1",
     "grunt-processhtml": "~0.3.0",
     "grunt-replace": "~0.7.7",
+    "grunt-tinypng": "^0.5.3",
+    "load-grunt-tasks": "^3.1.0",
     "mockjs": "^0.1.4"
   },
   "engines": {

--- a/app/templates/conf/_dev.json
+++ b/app/templates/conf/_dev.json
@@ -12,6 +12,10 @@
         "enable": true,
         "projectId": 1
     },
+    "tinypng": {
+        "enable": false,
+        "apiKey": "Oj3e9V0pJymoyt1jY482tqd1J-73OqIc"
+    },
     "views": [
         {
             "html": "index",


### PR DESCRIPTION
1、grunt加载task由手工转为自动化操作。  2、增加在线tinypng压缩图片功能，默认关闭，其实开启也可以，因为它对已经压缩过的图片会md5一下，后续调用也不会再对未改变的图片进行tinypng压缩，只是考虑到ui经常是和我们同步构台，有些图还没确认，就没必要浪费tinypng的压缩量